### PR TITLE
Add OpenAI details service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # code-secure-ai
+
+This repository contains a simple Go service that interacts with the OpenAI API. It accepts a full description of a SonarQube issue and returns additional guidance for fixing it. The service exposes a `/details` endpoint that expects a JSON body with the field `issue`.
+
+## Building
+
+Ensure you have Go installed. Then, run:
+
+```bash
+go build
+```
+
+## Running
+
+Set the `OPENAI_API_KEY` environment variable with your API key and start the service:
+
+```bash
+OPENAI_API_KEY=yourkey go run .
+```
+
+The service listens on port `8080`.
+
+## Request Example
+
+Send a POST request to `/details` with a JSON payload:
+
+```json
+{
+  "issue": "<descricao completa da issue do SonarQube, com referencia de arquivo e trecho de codigo>"
+}
+```
+
+The response will contain a `details` field with the explanation returned by OpenAI.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module code-secure-ai
+
+go 1.23.8

--- a/main.go
+++ b/main.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+)
+
+type request struct {
+	Issue string `json:"issue"`
+}
+
+type openaiMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openaiRequest struct {
+	Model    string          `json:"model"`
+	Messages []openaiMessage `json:"messages"`
+}
+
+type openaiChoice struct {
+	Message openaiMessage `json:"message"`
+}
+
+type openaiResponse struct {
+	Choices []openaiChoice `json:"choices"`
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		http.Error(w, "missing OPENAI_API_KEY", http.StatusInternalServerError)
+		return
+	}
+
+	oreq := openaiRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openaiMessage{
+			{Role: "system", Content: "Voce auxilia desenvolvedores a corrigir problemas de seguranca no codigo."},
+			{Role: "user", Content: "Forneca mais detalhes para corrigir o seguinte problema detectado pelo SonarQube:\n\n" + req.Issue},
+		},
+	}
+	body, err := json.Marshal(oreq)
+	if err != nil {
+		http.Error(w, "error encoding request", http.StatusInternalServerError)
+		return
+	}
+
+	httpReq, err := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", bytes.NewBuffer(body))
+	if err != nil {
+		http.Error(w, "error creating request", http.StatusInternalServerError)
+		return
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		http.Error(w, "error calling openai", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := ioutil.ReadAll(resp.Body)
+		http.Error(w, "openai error: "+string(b), http.StatusInternalServerError)
+		return
+	}
+
+	var oresp openaiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&oresp); err != nil {
+		http.Error(w, "error decoding response", http.StatusInternalServerError)
+		return
+	}
+	if len(oresp.Choices) == 0 {
+		http.Error(w, "openai returned no choices", http.StatusInternalServerError)
+		return
+	}
+
+	result := map[string]string{"details": oresp.Choices[0].Message.Content}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+func main() {
+	http.HandleFunc("/details", handler)
+	log.Println("listening on :8080")
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- initialize Go module
- add service to fetch extra details from OpenAI API
- document build and run instructions

## Testing
- `go vet ./...`
